### PR TITLE
Use `diff` hint for cloudbuild.yaml migration snippet

### DIFF
--- a/Beta/add-builder.sh
+++ b/Beta/add-builder.sh
@@ -30,7 +30,7 @@ http://TODO
 To migrate from \`gcr.io/cloud-builders/$1\` to this image, make the following
 changes to your \`cloudbuild.yaml\`:
 
-\`\`\`
+\`\`\`diff
 - name: 'gcr.io/cloud-builders/$1'
 + name: '{region}-docker.pkg.dev/gcb-release/cloud-builders/$1'
 \`\`\`

--- a/Beta/bazel/README.md
+++ b/Beta/bazel/README.md
@@ -10,7 +10,7 @@ For details, please visit gcr.io/cloud-marketplace-containers/google/bazel.
 To migrate from `gcr.io/cloud-builders/bazel` to this image, make the following
 changes to your `cloudbuild.yaml`:
 
-```
+```diff
 - name: 'gcr.io/cloud-builders/bazel'
 + name: '{region}-docker.pkg.dev/gcb-release/cloud-builders/bazel'
 ```

--- a/Beta/curl/README.md
+++ b/Beta/curl/README.md
@@ -13,7 +13,7 @@ https://hub.docker.com/r/curlimages/curl.
 To migrate from `gcr.io/cloud-builders/curl` to this image, make the following
 changes to your `cloudbuild.yaml`:
 
-```
+```diff
 - name: 'gcr.io/cloud-builders/curl'
 + name: '{region}-docker.pkg.dev/gcb-release/cloud-builders/curl'
 ```

--- a/Beta/docker/README.md
+++ b/Beta/docker/README.md
@@ -10,7 +10,7 @@ https://hub.docker.com/_/docker.
 To migrate from `gcr.io/cloud-builders/docker` to this image, make the following
 changes to your `cloudbuild.yaml`:
 
-```
+```diff
 - name: 'gcr.io/cloud-builders/docker'
 + name: '{region}-docker.pkg.dev/gcb-release/cloud-builders/docker'
 ```

--- a/Beta/gcloud/README.md
+++ b/Beta/gcloud/README.md
@@ -12,7 +12,7 @@ https://github.com/GoogleCloudPlatform/cloud-sdk-docker.
 To migrate from `gcr.io/cloud-builders/gcloud` to this image, make the following
 changes to your `cloudbuild.yaml`:
 
-```
+```diff
 - name: 'gcr.io/cloud-builders/gcloud'
 + name: '{region}-docker.pkg.dev/gcb-release/cloud-builders/gcloud'
 ```

--- a/Beta/gcs-fetcher/README.md
+++ b/Beta/gcs-fetcher/README.md
@@ -6,7 +6,7 @@ is regionally distributed alongside our Beta Builders.
 To migrate from `gcr.io/cloud-builders/gcs-fetcher` to this image, make the following
 changes to your `cloudbuild.yaml`:
 
-```
+```diff
 - name: 'gcr.io/cloud-builders/gcs-fetcher'
 + name: '{region}-docker.pkg.dev/gcb-release/cloud-builders/gcs-fetcher'
 ```

--- a/Beta/git/README.md
+++ b/Beta/git/README.md
@@ -12,7 +12,7 @@ image.
 To migrate from `gcr.io/cloud-builders/git` to this image, make the following
 changes to your `cloudbuild.yaml`:
 
-```
+```diff
 - name: 'gcr.io/cloud-builders/git'
 + name: '{region}-docker.pkg.dev/gcb-release/cloud-builders/git'
 ```

--- a/Beta/gke-deploy/README.md
+++ b/Beta/gke-deploy/README.md
@@ -6,7 +6,7 @@ is regionally distributed alongside our Beta Builders.
 To migrate from `gcr.io/cloud-builders/gke-deploy` to this image, make the following
 changes to your `cloudbuild.yaml`:
 
-```
+```diff
 - name: 'gcr.io/cloud-builders/gke-deploy'
 + name: '{region}-docker.pkg.dev/gcb-release/cloud-builders/gke-deploy'
 ```

--- a/Beta/go/README.md
+++ b/Beta/go/README.md
@@ -9,7 +9,7 @@ platforms. For details, please visit https://hub.docker.com/_/golang.
 To migrate from `gcr.io/cloud-builders/go` to this image, make the following
 changes to your `cloudbuild.yaml`:
 
-```
+```diff
 - name: 'gcr.io/cloud-builders/go'
 + name: '{region}-docker.pkg.dev/gcb-release/cloud-builders/go'
 ```

--- a/Beta/gradle/README.md
+++ b/Beta/gradle/README.md
@@ -10,7 +10,7 @@ https://hub.docker.com/_/gradle for details.
 To migrate from `gcr.io/cloud-builders/gradle` to this image, make the following
 changes to your `cloudbuild.yaml`:
 
-```
+```diff
 - name: 'gcr.io/cloud-builders/gradle'
 + name: '{region}-docker.pkg.dev/gcb-release/cloud-builders/gradle'
 ```

--- a/Beta/gsutil/README.md
+++ b/Beta/gsutil/README.md
@@ -12,7 +12,7 @@ https://github.com/GoogleCloudPlatform/cloud-sdk-docker.
 To migrate from `gcr.io/cloud-builders/gsutil` to this image, make the following
 changes to your `cloudbuild.yaml`:
 
-```
+```diff
 - name: 'gcr.io/cloud-builders/gsutil'
 + name: '{region}-docker.pkg.dev/gcb-release/cloud-builders/gsutil'
 ```

--- a/Beta/javac/README.md
+++ b/Beta/javac/README.md
@@ -10,7 +10,7 @@ For details, please visit https://hub.docker.com/_/openjdk.
 To migrate from `gcr.io/cloud-builders/javac` to this image, make the following
 changes to your `cloudbuild.yaml`:
 
-```
+```diff
 - name: 'gcr.io/cloud-builders/javac'
 + name: '{region}-docker.pkg.dev/gcb-release/cloud-builders/javac'
 ```

--- a/Beta/kubectl/README.md
+++ b/Beta/kubectl/README.md
@@ -12,7 +12,7 @@ https://github.com/GoogleCloudPlatform/cloud-sdk-docker.
 To migrate from `gcr.io/cloud-builders/kubectl` to this image, make the following
 changes to your `cloudbuild.yaml`:
 
-```
+```diff
 - name: 'gcr.io/cloud-builders/kubectl'
 + name: '{region}-docker.pkg.dev/gcb-release/cloud-builders/kubectl'
 ```

--- a/Beta/mvn/README.md
+++ b/Beta/mvn/README.md
@@ -10,7 +10,7 @@ platforms. Please visit https://hub.docker.com/_/maven for details.
 To migrate from `gcr.io/cloud-builders/mvn` to this image, make the following
 changes to your `cloudbuild.yaml`:
 
-```
+```diff
 - name: 'gcr.io/cloud-builders/mvn'
 + name: '{region}-docker.pkg.dev/gcb-release/cloud-builders/mvn'
 ```

--- a/Beta/npm/README.md
+++ b/Beta/npm/README.md
@@ -10,7 +10,7 @@ for details.
 To migrate from `gcr.io/cloud-builders/npm` to this image, make the following
 changes to your `cloudbuild.yaml`:
 
-```
+```diff
 - name: 'gcr.io/cloud-builders/npm'
 + name: '{region}-docker.pkg.dev/gcb-release/cloud-builders/npm'
 ```

--- a/Beta/wget/README.md
+++ b/Beta/wget/README.md
@@ -12,7 +12,7 @@ in a variety of versions across multiple platforms in community-maintained
 To migrate from `gcr.io/cloud-builders/wget` to this image, make the following
 changes to your `cloudbuild.yaml`:
 
-```
+```diff
 - name: 'gcr.io/cloud-builders/wget'
 + name: '{region}-docker.pkg.dev/gcb-release/cloud-builders/wget'
 ```

--- a/Beta/yarn/README.md
+++ b/Beta/yarn/README.md
@@ -10,7 +10,7 @@ for details.
 To migrate from `gcr.io/cloud-builders/yarn` to this image, make the following
 changes to your `cloudbuild.yaml`:
 
-```
+```diff
 - name: 'gcr.io/cloud-builders/yarn'
 + name: '{region}-docker.pkg.dev/gcb-release/cloud-builders/yarn'
 ```


### PR DESCRIPTION
Use the `diff` hint to provide a visual indication that the migration snippets are diffs:

```diff
- name: 'gcr.io/cloud-builders/bazel'
+ name: '{region}-docker.pkg.dev/gcb-release/cloud-builders/bazel'
```

I initally thought the text shown was a YAML snippet, and did a double-take on the `+`.